### PR TITLE
fix: Add mobile touch event support for clock dragging

### DIFF
--- a/components/TimerWidget.tsx
+++ b/components/TimerWidget.tsx
@@ -38,7 +38,7 @@ export const TimerWidget: React.FC = () => {
   const wakeLockRef = useRef<any>(null);
 
   // Initial center position (approx)
-  const { position, handleMouseDown, isDragging } = useDraggable({ x: window.innerWidth / 2 - 160, y: window.innerHeight / 2 - 100 });
+  const { position, handleMouseDown, handleTouchStart, isDragging } = useDraggable({ x: window.innerWidth / 2 - 160, y: window.innerHeight / 2 - 100 });
 
   // Clock Tick (Current Time)
   useEffect(() => {
@@ -261,6 +261,7 @@ export const TimerWidget: React.FC = () => {
         zIndex: 9999,
       }}
       onMouseDown={handleMouseDown}
+      onTouchStart={handleTouchStart}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
     >

--- a/hooks/useDraggable.ts
+++ b/hooks/useDraggable.ts
@@ -11,11 +11,25 @@ export const useDraggable = (initialPosition: Position) => {
     if ((e.target as HTMLElement).tagName === 'INPUT' || (e.target as HTMLElement).tagName === 'BUTTON') {
       return;
     }
-    
+
     setIsDragging(true);
     setOffset({
       x: e.clientX - position.x,
       y: e.clientY - position.y
+    });
+  }, [position]);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    // Prevent dragging if interacting with inputs or buttons
+    if ((e.target as HTMLElement).tagName === 'INPUT' || (e.target as HTMLElement).tagName === 'BUTTON') {
+      return;
+    }
+
+    const touch = e.touches[0];
+    setIsDragging(true);
+    setOffset({
+      x: touch.clientX - position.x,
+      y: touch.clientY - position.y
     });
   }, [position]);
 
@@ -28,7 +42,21 @@ export const useDraggable = (initialPosition: Position) => {
     }
   }, [isDragging, offset]);
 
+  const handleTouchMove = useCallback((e: TouchEvent) => {
+    if (isDragging) {
+      const touch = e.touches[0];
+      setPosition({
+        x: touch.clientX - offset.x,
+        y: touch.clientY - offset.y
+      });
+    }
+  }, [isDragging, offset]);
+
   const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
     setIsDragging(false);
   }, []);
 
@@ -36,15 +64,21 @@ export const useDraggable = (initialPosition: Position) => {
     if (isDragging) {
       window.addEventListener('mousemove', handleMouseMove);
       window.addEventListener('mouseup', handleMouseUp);
+      window.addEventListener('touchmove', handleTouchMove);
+      window.addEventListener('touchend', handleTouchEnd);
     } else {
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
+      window.removeEventListener('touchmove', handleTouchMove);
+      window.removeEventListener('touchend', handleTouchEnd);
     }
     return () => {
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
+      window.removeEventListener('touchmove', handleTouchMove);
+      window.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [isDragging, handleMouseMove, handleMouseUp]);
+  }, [isDragging, handleMouseMove, handleMouseUp, handleTouchMove, handleTouchEnd]);
 
-  return { position, handleMouseDown, isDragging };
+  return { position, handleMouseDown, handleTouchStart, isDragging };
 };


### PR DESCRIPTION
- Added handleTouchStart, handleTouchMove, handleTouchEnd to useDraggable hook
- Properly handle touch events alongside mouse events
- Fixed mobile devices unable to drag the timer widget
- Event handlers follow same pattern as mouse events with proper cleanup