### PR TITLE
Improve time display visibility and font size

### DIFF
--- a/components/TimerWidget.tsx
+++ b/components/TimerWidget.tsx
@@ -287,7 +287,7 @@ export const TimerWidget: React.FC = () => {
         
         {/* Top Date/Time Header */}
         <div className="absolute top-6 w-full flex justify-center pointer-events-none">
-          <span className="text-[10px] font-bold text-zinc-500/80 tracking-[0.2em] font-sans">
+          <span className="text-xs font-bold text-white/90 tracking-[0.2em] font-sans drop-shadow-sm">
             {dayName} {timeString}
           </span>
         </div>


### PR DESCRIPTION
- Increased font size from 10px to 12px (20% larger)
- Improved contrast: zinc-500/80 → white/90 for better visibility
- Added drop-shadow for enhanced readability on all backgrounds
- Maintains eye-friendly design while ensuring clarity