### PR TITLE
Fix Google AI package dependency detection

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -90,7 +90,7 @@ echo "🔍 验证依赖完整性..."
 MISSING_DEPS=0
 
 # 检查生产依赖
-for pkg in react react-dom @google/generative-ai; do
+for pkg in react react-dom @google/genai motion; do
   if [ ! -d "node_modules/$(echo $pkg | tr '/' '/')" ]; then
     echo "   ❌ 缺少：$pkg"
     MISSING_DEPS=$((MISSING_DEPS + 1))


### PR DESCRIPTION
- Update install_deps.sh to check for @google/genai instead of legacy @google/generative-ai
- Add motion package to production dependency verification
- Aligns with official Google recommendation (GA since May 2025)

Note: @google/generative-ai is deprecated and support ends August 31, 2025